### PR TITLE
prompt user for workshop password

### DIFF
--- a/push/push.go
+++ b/push/push.go
@@ -170,6 +170,6 @@ func PushCmd() error {
 	}
 
 	fmt.Println("SUCCEEDED!")
-
+	fmt.Printf("Access the workshop at:\n https://%s.%s\n Username: %s\n Password: %s", hostname, resources.CfDomain, resources.WorkshopUser, sitePass)
 	return nil
 }

--- a/push/push.go
+++ b/push/push.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Pallinder/sillyname-go"
 	"github.com/Pivotal-Field-Engineering/pace-builder/resources"
 	"github.com/cloudfoundry-community/go-cfclient"
+	"github.com/foomo/htpasswd"
 	"github.com/pierrre/archivefile/zip"
 )
 
@@ -31,6 +32,18 @@ func PushCmd() error {
 	if len(username) < 3 {
 		return fmt.Errorf("That's not your username! Try again....")
 	}
+
+	fmt.Print("Enter Workshop Website Password - [pivotal]: ")
+	sitePass, _ := reader.ReadString('\n')
+	sitePass = strings.Replace(sitePass, "\n", "", -1)
+	if len(sitePass) < 1 {
+		fmt.Println("Password defaulting to \"pivotal\"")
+		sitePass = "pivotal"
+	}
+
+	authFile := "publicGen/Staticfile.auth"
+
+	err := htpasswd.SetPassword(authFile, resources.WorkshopUser, sitePass, htpasswd.HashSHA)
 
 	config, err := resources.DetermineConfig("config.json")
 	if err != nil {

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 )
 
+var WorkshopUser = "pivotal"
 var PaceSpaceGUID = "08dba6e1-270b-4cdc-9869-61bc44530030"
 var PaceOrgGUID = "9284317b-6e22-4d94-87b4-b442b157965d"
 


### PR DESCRIPTION
Due to concerns around keeping workshops wide open for the world, we now will prompt users for a password. If password is not specified `pivotal`/`pivotal` will be username and password.